### PR TITLE
Add auth flow placeholder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import KeyIdea from './KeyIdea';
 import PhilosophersKeyIdeas from './PhilosophersKeyIdeas';
 import PhilosophersMap from './PhilosophersMap';
 import Timeline from './Timeline';
+import Auth from './Auth';
 
 
 function App() {
@@ -68,6 +69,7 @@ const AppContent: React.FC = () => {
           <Route path="/search" element={<Search />} />
           <Route path="/map" element={<PhilosophersMap />} />
           <Route path="/timeline" element={<Timeline />} />
+          <Route path="/auth" element={<Auth />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/profile/:username" element={<Profile />} />
           <Route path="/profile/:username/ebooks" element={<EBooks />} />

--- a/src/Auth.tsx
+++ b/src/Auth.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Auth: React.FC = () => {
+  return (
+    <div style={{ padding: '40px', textAlign: 'center' }}>
+      <h2>Authentication Page</h2>
+      {/* TODO: add real auth form */}
+    </div>
+  );
+};
+
+export default Auth;

--- a/src/Profile.tsx
+++ b/src/Profile.tsx
@@ -88,7 +88,29 @@ const Profile: React.FC = () => {
     const state = location.state as { backgroundLocation?: Location };
 
     // Determine if this is the current user's profile
-    const isCurrentUser = !username || username === User.current.username;
+    const isCurrentUser = !!User.current && (!username || username === User.current.username);
+
+    if (!User.current && !username) {
+        return (
+            <div style={{ display: 'flex', justifyContent: 'center', padding: '40px' }}>
+                <button
+                    onClick={() => navigate('/auth')}
+                    style={{
+                        padding: '10px 20px',
+                        backgroundColor: colors.blue,
+                        color: colors.white,
+                        border: 'none',
+                        borderRadius: '30px',
+                        cursor: 'pointer',
+                        fontSize: '1em',
+                        fontWeight: 700,
+                    }}
+                >
+                    Sign In
+                </button>
+            </div>
+        );
+    }
 
     const handleBack = () => {
         navigate(-1);
@@ -142,7 +164,7 @@ const Profile: React.FC = () => {
     React.useEffect(() => {
         const originalTitle = document.title;
 
-        if (isCurrentUser) {
+        if (isCurrentUser && User.current) {
             document.title = `${User.current.name} - Philosophers`;
         } else if (data?.philosopherByUsername) {
             document.title = `${data.philosopherByUsername.name} - Philosophers`;

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -204,7 +204,7 @@ const Sidebar: React.FC<SidebarProps> = ({ compact = false }) => {
 
             <Spacer />
 
-            {!compact && (
+            {!compact && User.current && (
                 <div
                     className={"nav-link"}
                     style={{
@@ -227,6 +227,27 @@ const Sidebar: React.FC<SidebarProps> = ({ compact = false }) => {
                         imageWidth='40px'
                         imageHeight='40px'
                     />
+                </div>
+            )}
+
+            {!compact && !User.current && (
+                <div style={{ margin: '0 30px 20px 30px' }}>
+                    <button
+                        onClick={() => navigate('/auth')}
+                        style={{
+                            width: '100%',
+                            padding: '10px 15px',
+                            backgroundColor: colors.blue,
+                            color: colors.white,
+                            border: 'none',
+                            borderRadius: '30px',
+                            cursor: 'pointer',
+                            fontSize: '1em',
+                            fontWeight: 700,
+                        }}
+                    >
+                        Sign In
+                    </button>
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Summary
- add a bare-bones `Auth` page
- link new `/auth` page in router
- show a Sign In button in the sidebar when no user is set
- guard `/profile` by showing the same Sign In button if not logged in

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc37167b4832b925ee3160c59a90f