### PR TITLE
Adjust sign-in button spacing

### DIFF
--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -256,7 +256,7 @@ const Sidebar: React.FC<SidebarProps> = ({ compact = false }) => {
             )}
 
             {!compact && !User.current && (
-                <div style={{ margin: '0 30px 20px 30px' }}>
+                <div style={{ margin: '0 30px 40px 30px' }}>
                     <button
                         onClick={() => navigate('/auth')}
                         style={{


### PR DESCRIPTION
## Summary
- bump margin below sidebar sign-in button so it isn't flush with the bottom of the window

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4df81f60832b9a5bd106c072f9ab